### PR TITLE
fix: remove "await" from `createFrame`

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ let callFrame, room;
 
 async function createCallframe() {
   const callWrapper = document.getElementById('wrapper');
-  callFrame = await window.DailyIframe.createFrame(callWrapper);
+  callFrame = window.DailyIframe.createFrame(callWrapper);
 
   callFrame
     .on('loaded', showEvent)


### PR DESCRIPTION
`createFrame` doesn't return a Promise (https://docs.daily.co/reference/daily-js/factory-methods/create-frame) so the `await` here is unnecessary.